### PR TITLE
Refactor as "Stable Formatting"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# An Explicit Root Locale
+# An Explicit Null Locale
 
-A TC-39 proposal to define the behaviour and properties of the `"und"` root locale.
+A TC-39 proposal to define the behaviour and properties of the `zxx` null locale.
 
 **Stage:** 0
 
@@ -27,28 +27,41 @@ is to [use Swedish as the locale](https://stackoverflow.com/a/58633686).
 
 ## Possible Solution
 
-We should define in ECMA-402 the behaviour of each of the formatters for the `"und"` root locale.
-This locale identifier (short for "undetermined") is a valid BCP 47 primary language tag defined in ISO 639.2,
-and it's recognised by numerous other existing systems.
+We should define in ECMA-402 the behaviour of each of the formatters for the `zxx` null locale.
+This locale identifier (which stands for for "no linguistic content; not applicable")
+is a valid BCP 47 primary language tag defined in ISO 639.2
+but its behaviour is not otherwise well defined.
 
-Wherever possible, the `"und"` locale should use well-defined standardized behaviour,
+For ease of use,
+Intl formatters should accept `null` as an alias for the canonical `"zxx"` identifier.
+
+Wherever possible, the `zxx` locale should use well-defined standardized behaviour,
 such as using ISO-8601 for date formatting.
 
-The "localized" output for `"und"` should avoid including actually localized text in its output,
+The "localized" output for `zxx` should avoid including actually localized text in its output,
 such as fully written-out unit names or the names of months.
 
 ```js
-Intl.Collator.supportedLocalesOf('und') → ['und']
+Intl.Collator.supportedLocalesOf(null) → ['zxx']
 
-new Intl.DateTimeFormat('und').format(new Date()) === '2023-09-01'
+new Intl.DateTimeFormat('zxx').format(new Date()) === '2023-09-01'
 
-(12345.67).toLocaleString('und') === '12345.67'
+(12345.67).toLocaleString(null) === '12345.67'
 ```
+
+## Alternatives
+
+A prior version of this proposal used the "undetermined" `und` locale instead of `zxx`.
+This is also a valid ISO 639.2 language identifier,
+but it is used as the canonical root locale identifier in CLDR,
+which has well-defined behaviour e.g. in
+[java.util.Locale](https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html).
+
+The `und` locale is also currently supported by Safari as an alias for `en-US-u-va-posix`,
+and it's recognised by Chrome and Node.js for `Intl.Locale`.
 
 ## Prior Art
 
 - [ISO 639-2](https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes)
 - [BCP 47 / RFC 5646](https://www.rfc-editor.org/rfc/rfc5646.html)
 - [Unicode Technical Standard #35 (LDML)](https://unicode.org/reports/tr35/)
-- [java.util.Locale](https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html)
-- [PostgreSQL collation](https://www.postgresql.org/docs/current/collation.html)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# An Explicit Null Locale
+# Stable Formatting
 
-A TC-39 proposal to define the behaviour and properties of the `zxx` null locale.
+A TC-39 proposal to provide well-defined and powerful formatting methods.
 
 **Stage:** 0
 
@@ -26,6 +26,11 @@ For example, the top StackOverflow suggestion for how to format a date using ISO
 is to [use Swedish as the locale](https://stackoverflow.com/a/58633686).
 
 ## Possible Solution
+
+> [!NOTE]
+> It's entirely possible for a solution to this to be found in ECMA-262 outside `Intl`;
+> the following is one possible approach that extends the `Intl` formatters
+> to support non-internationalization usage for the desired formatting.
 
 We should define in ECMA-402 the behaviour of each of the formatters for the `zxx` null locale.
 This locale identifier (which stands for for "no linguistic content; not applicable")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stable Formatting
 
-A TC-39 proposal to provide well-defined and powerful formatting methods.
+A TC-39 proposal to bring stable Intl-inspired formatting options to ECMAScript.
 
 **Stage:** 0
 


### PR DESCRIPTION
Closes #1 
Closes #3 
Closes #5
Closes #6

Based on comments from @aphillips and @justingrant, it's probably best to call this a "null locale" and use `zxx` rather than `und` as its identifier.

After merging, the repo should also be renamed.