### PR TITLE
Use `Intl.STABLE` instead of `null`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ is to [use Swedish as the locale](https://stackoverflow.com/a/58633686).
 
 ## Proposed Solution
 
-Define in ECMA-402 the behaviour of each of the formatters for the `zxx` null locale.
+Define in ECMA-402 the behaviour of each of the formatters for the `zxx` locale.
 This locale identifier (which stands for for "no linguistic content; not applicable")
 is a valid BCP 47 primary language tag defined in ISO 639.2
 but its behaviour is not otherwise well defined.
 
 For ease of use,
-Intl formatters would accept `null` as an alias for the canonical `"zxx"` identifier.
+the value property `Intl.STABLE` is added with the string value `"zxx"`.
 
 Wherever possible, the `zxx` locale would use well-defined standardized behaviour,
 such as using ISO-8601 for date formatting.
@@ -53,11 +53,11 @@ The "localized" output for `zxx` would avoid including actually localized text i
 such as fully written-out unit names or the names of months.
 
 ```js
-Intl.Collator.supportedLocalesOf(null) → ['zxx']
+Intl.Collator.supportedLocalesOf(Intl.STABLE) → ['zxx']
 
 new Intl.DateTimeFormat('zxx').format(new Date()) === '2023-09-01'
 
-(12345.67).toLocaleString(null) === '12345.67'
+(12345.67).toLocaleString(Intl.STABLE) === '12345.67'
 ```
 
 ### Intl.Collator
@@ -85,7 +85,7 @@ e.g. `2006-01-02`, `15:04:05`, `2006-01-02T15:04:05.999+01:00[Europe/Paris]`.
 Only numerical representations of time and date values are used, as in:
 
 ```js
-const dtf = new Intl.DateTimeFormat(null, { month: "long" });
+const dtf = new Intl.DateTimeFormat(Intl.STABLE, { month: "long" });
 dtf.format(new Date("2006-01-02")) === "1";
 ```
 

--- a/spec.html
+++ b/spec.html
@@ -68,6 +68,19 @@ contributors: Eemeli Aro
   </emu-clause>
 </emu-clause>
 
+<emu-clause id="intl-object" number="8">
+  <h1>Value Properties of the Intl Object</h1>
+
+  <emu-clause id="sec-intl.stable" number="1.2">
+    <h1><ins>Intl.STABLE</ins></h1>
+    <p>
+      The String value *"zxx"*, the language tag for "no linguistic content".
+      Used to elicit stable behaviour in formatters.
+    </p>
+    <p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
+  </emu-clause>
+</emu-clause>
+
 <emu-clause id="locale-and-parameter-negotiation" number="9">
   <h1>Locale and Parameter Negotiation</h1>
 


### PR DESCRIPTION
As discussed at the last TC39 plenary, rather than defining special behaviour for `null` when it's used as a locale, let's instead add a constant `Intl.STABLE` with the string value `'zxx'` so that it can be used instead of the raw value, as in:

```js
new Intl.NumberFormat(Intl.STABLE)
```