### PR TITLE
Use easier-to-specify stable behaviour for DurationFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ depending on the `fallback` option.
 ### Intl.DurationFormat
 
 When the `zxx` locale is used with valid formatting options,
-the formatted duration is an ISO 8601-2 duration,
-such as `P2Y` (2 years), `PT2H30M` (2 hours and 30 minutes), or `P5DT0.001S` (5 days and 1 millisecond).
+the formatted duration is a concatenation of `'{number} {unit}'` entries separated by `', '`,
+such as `2 year`, `2 hour, 30 minute`, or `5 day, 1 millisecond`,
+or time values separated by `:` with `style: 'digital'`.
 
 ### Intl.ListFormat
 

--- a/spec.html
+++ b/spec.html
@@ -327,6 +327,46 @@ contributors: Eemeli Aro
   </emu-clause>
 </emu-clause>
 
+<emu-clause id="durationformat-objects" number="13">
+  <h1>DurationFormat Objects</h1>
+
+  <emu-clause id="sec-Intl.DurationFormat-internal-slots" number="2.3">
+    <h1>Internal slots</h1>
+
+    <p>The value of the [[AvailableLocales]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref>.</p>
+
+    <p>The value of the [[RelevantExtensionKeys]] internal slot is « *"nu"* ».</p>
+
+    <p>The value of the [[ResolutionOptionDescriptors]] internal slot is « { [[Key]]: *"nu"*, [[Property]]: *"numberingSystem"* } ».</p>
+
+    <p>The value of the [[LocaleData]] internal slot is implementation-defined within the constraints described in <emu-xref href="#sec-internal-slots"></emu-xref> and the following additional constraints for all locale values _locale_:</p>
+
+    <ul>
+      <li>[[LocaleData]].[[&lt;_locale_>]] must be a Record with fields [[nu]] and [[DigitalFormat]].</li>
+      <li>[[LocaleData]].[[&lt;_locale_>]].[[nu]] must be a List as specified in <emu-xref href="#sec-intl.numberformat-internal-slots"></emu-xref> and must not include the values *"native"*, *"traditio"*, or *"finance"*.</li>
+      <li>[[LocaleData]].[[&lt;_locale_>]].[[DigitalFormat]] must be a Record with keys corresponding to each numbering system available for _locale_. Each value associated with one of those keys must be a Record containing the following fields:
+        <ul>
+          <li>[[HourMinuteSeparator]] must be a String value that is the appropriate separator between hours and minutes for that combination of locale and numbering system when using style *"numeric"* or *"2-digit"*.</li>
+          <li>[[MinuteSecondSeparator]] must be a String value that is the appropriate separator between minutes and seconds for that combination of locale and numbering system when using style *"numeric"* or *"2-digit"*.</li>
+          <li>[[TwoDigitHours]] must be a Boolean value indicating whether hours are always displayed using two digits when using style *"numeric"*.</li>
+        </ul>
+      </li>
+      <li>
+        <ins class="block">
+          For the _locale_ *"zxx"* and the _calendar_ *"latn"*, the [[LocaleData]].[[&lt;_locale_>]].[[DigitalFormat]].[[&lt;_calendar_>]] Record must have the following values:
+          <ul>
+            <li>[[HourMinuteSeparator]]: *":"*</li>
+            <li>[[MinuteSecondSeparator]]: *":"*</li>
+            <li>[[TwoDigitHours]]: *true*</li>
+          </ul>
+        </ins>
+      </li>
+    </ul>
+
+    <emu-note>It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).</emu-note>
+  </emu-clause>
+</emu-clause>
+
 <emu-clause id="listformat-objects" number="14">
   <h1>ListFormat Objects</h1>
 


### PR DESCRIPTION
When putting together the earlier proposal for DurationFormat's stable behaviour, I had not taken into account the way that it's defined in terms of NumberFormat and ListFormat, which means that emitting ISO 8601-2 durations with it would effectively require a completely custom code path.

Rather than implementing that, let's instead allow DurationFormat to use the stable behaviours we're defining for Numberformat and ListFormat.

RelativeTimeFormat is wired up completely differently, so that can (and should) still be set up to return ISO 8601-2 durations.