### PR TITLE
Advance to Stage 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A TC39 proposal to bring stable Intl-inspired formatting options to ECMAScript.
 
-**Stage:** 1
+**Stage:** 2
 
 **Presentations**:
 - Stage 1 (2023-09):

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A TC39 proposal to bring stable Intl-inspired formatting options to ECMAScript.
 
 **Stage:** 2
 
+**Champion**: [Eemeli Aro](https://github.com/eemeli)
+
+**Reviewers**: [Richard Gibson](https://github.com/gibson042), [Dan Minor](https://github.com/dminor)
+
 **Presentations**:
 - Stage 1 (2023-09):
   [Slides](https://docs.google.com/presentation/d/1p1Xgywv1qfY54gnfHUM6PXQafqgf7wY98znxbolmP2c/edit?usp=sharing),
@@ -12,6 +16,8 @@ A TC39 proposal to bring stable Intl-inspired formatting options to ECMAScript.
   [PR #18](https://github.com/tc39/proposal-stable-formatting/pull/18),
   [Slides](https://docs.google.com/presentation/d/14KQA1Gyy0reIyouHtzp5ofYRrcwRjkY6GajeknLWhg0/edit?usp=sharing),
   [Notes](https://github.com/tc39/notes/blob/main/meetings/2025-02/february-19.md#stable-formatting-update)
+- Stage 2 (2026-05):
+  [Slides](https://docs.google.com/presentation/d/1Vnt2-ejFMpk3NstM2DS0TtSRIoDqm9jqE4siiuMe4qE/edit?usp=sharing)
 
 ## Motivation
 

--- a/spec.html
+++ b/spec.html
@@ -3,7 +3,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
 <pre class="metadata">
 title: Stable Formatting
-stage: 1
+stage: 2
 contributors: Eemeli Aro
 </pre>
 


### PR DESCRIPTION
This is conditional on the following proposed changes being resolved, and on approval from TG2:
- #21 
- #22 
- #23 
- #24 
- #27

A version of the spec text if/after the above are merged is available at https://tc39.es/proposal-stable-formatting/, rendered from the (temporary) `next` branch of this repo.

Note that the DateTimeFormat [[formats]] and [[styles]] data is still marked as TODO, but the intended behaviour is [described](https://github.com/tc39/proposal-stable-formatting#intldatetimeformat) in the README.