### PR TITLE
Use "SE mil" as short unit for `mile-scandinavian`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -118,7 +118,7 @@ contributors: Eemeli Aro
         <tr><td>meter</td><td><ins>m</ins></td></tr>
         <tr><td>microsecond</td><td><ins>μs</ins></td></tr>
         <tr><td>mile</td><td><ins>mi</ins></td></tr>
-        <tr><td>mile-scandinavian</td><td><ins>mil</ins></td></tr>
+        <tr><td>mile-scandinavian</td><td><ins>SE mil</ins></td></tr>
         <tr><td>milliliter</td><td><ins>mL</ins></td></tr>
         <tr><td>millimeter</td><td><ins>mm</ins></td></tr>
         <tr><td>millisecond</td><td><ins>ms</ins></td></tr>


### PR DESCRIPTION
During the TC39 TG1 discussion for the proposal, the short unit identifiers (#27) were presented. Some concerns were raised about using "mil" as the short form for `mile-scandinavian`, in particular regarding potential confusion with the US customary unit "mil", which is one thousandth of an inch.

Therefore, let's use the same approach as we're using for `fluid-ounce` and `gallon`, and prefix the unit identifier with its common region of usage (Sweden): `SE mil`.