### PR TITLE
Include testing as a motivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Recent examples are available from
 [this presentation](https://docs.google.com/presentation/d/1KuIOSDQRliqCT3x3WX9Bg9H3hndfhAcH2G0aNoBKq18/edit#slide=id.p) from
 [June 2023 TC39-TG2](https://github.com/tc39/ecma402/blob/master/meetings/notes-2023-06-01.md#how-to-prevent-misuse-of-localized-strings).
 
-The lack of stability also makes it challenging to test `Intl` APIs,
-as implementation differences can preduce different results in different environments.
+The lack of stability also makes it challenging to test `Intl` APIs
+or websites and applications that rely on `Intl` APIs,
+as implementation differences can produce different results in different environments.
 
 Separately, sometimes it is desirable to format values for an international audience,
 or for other reasons use formats that are not tied to a specific locale.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Recent examples are available from
 [this presentation](https://docs.google.com/presentation/d/1KuIOSDQRliqCT3x3WX9Bg9H3hndfhAcH2G0aNoBKq18/edit#slide=id.p) from
 [June 2023 TC39-TG2](https://github.com/tc39/ecma402/blob/master/meetings/notes-2023-06-01.md#how-to-prevent-misuse-of-localized-strings).
 
+The lack of stability also makes it challenging to test `Intl` APIs,
+as implementation differences can preduce different results in different environments.
+
 Separately, sometimes it is desirable to format values for an international audience,
 or for other reasons use formats that are not tied to a specific locale.
 The `Intl` formatters do not currently support this well.


### PR DESCRIPTION
As noted in #39, the [Stage 2 presentation](https://docs.google.com/presentation/d/1Vnt2-ejFMpk3NstM2DS0TtSRIoDqm9jqE4siiuMe4qE/edit?usp=sharing) of this proposal included the following as its primary motivation (emphasis added):

> `Intl` provides many useful formatters and other locale-dependent functions.
>
> Sometimes, these are useful in locale-independent situations, **_including test suites_**. Often default or well-defined functionality is accessed via locales that happen to provide it at the moment.

This aspect is here more explicitly included in the README for the proposal.